### PR TITLE
Use errbase for universal error reporting

### DIFF
--- a/lib/ruby_branch/api/resources/link.rb
+++ b/lib/ruby_branch/api/resources/link.rb
@@ -107,9 +107,7 @@ module RubyBranch
 
         def process_error(response)
           error_attrs = { status: response.status, body: response.body }
-          if defined?(Bugsnag) && defined?(Rails) && Rails.env.production?
-            Bugsnag.notify(Errors::ApiResponseError.new, error_attrs)
-          end
+          Errbase.report(Errors::ApiResponseError.new, error_attrs)
         end
 
       end

--- a/ruby_branch.gemspec
+++ b/ruby_branch.gemspec
@@ -31,6 +31,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "faraday"
   spec.add_dependency "addressable"
+  spec.add_dependency "errbase"
 
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"


### PR DESCRIPTION
[errbase](http://github.com/ankane/errbase) is a nice gem that helps library like `ruby_branch` to integrate with common error reporting services.